### PR TITLE
normalize show title

### DIFF
--- a/default.py
+++ b/default.py
@@ -187,7 +187,7 @@ def formatNumber(number):
 def formatName(filename):
     filename = filename.strip()
     filename = filename.replace(' ', '.')
-    return filename	 
+    return normalizeString(filename)
     
 def notif(msg, time=5000):
     xbmcgui.Dialog().notification(encode(__scriptname__), encode(msg), time=time, icon=__icon__)
@@ -203,6 +203,9 @@ def encode(string):
     except UnicodeDecodeError:
         result = 'Unicode Error'
     return result
+
+def normalizeString(str):
+    return unicodedata.normalize('NFKD', str).encode('ascii','ignore').encode('UTF-8','replace')
 
 if ( __name__ == "__main__" ):
     player = Player()

--- a/program.py
+++ b/program.py
@@ -182,7 +182,7 @@ def formatNumber(number):
 def formatName(filename):
     filename = filename.strip()
     filename = filename.replace(' ', '.')
-    return filename	 
+    return normalizeString(filename)
     
 def notif(msg, time=5000):
     xbmcgui.Dialog().notification(encode(__scriptname__), encode(msg), time=time, icon=__icon__)
@@ -198,5 +198,8 @@ def encode(string):
     except UnicodeDecodeError:
         result = 'Unicode Error'
     return result         
+
+def normalizeString(str):
+    return unicodedata.normalize('NFKD', str).encode('ascii','ignore').encode('UTF-8','replace')
 
 start()


### PR DESCRIPTION
Fixing show title "Až po uši" to "Az po usi"
```
 - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
Error Type: <type 'exceptions.UnicodeEncodeError'>
Error Contents: 'ascii' codec can't encode character u'\u017e' in position 1: ordinal not in range(128)
Traceback (most recent call last):
  File "/Users/beam/Library/Application Support/Kodi/addons/script.tvshowtime/program.py", line 202, in <module>
    start()
  File "/Users/beam/Library/Application Support/Kodi/addons/script.tvshowtime/program.py", line 56, in start
    first_step()
  File "/Users/beam/Library/Application Support/Kodi/addons/script.tvshowtime/program.py", line 101, in first_step
    scan(which_way, tvshowsid[whattvshow])
  File "/Users/beam/Library/Application Support/Kodi/addons/script.tvshowtime/program.py", line 169, in scan
    checkin = MarkAsUnWatched(__token__, filename)
  File "/Users/beam/Library/Application Support/Kodi/addons/script.tvshowtime/resources/lib/tvshowtime.py", line 131, in __init__
    'filename' : self.filename
  File "/Users/Shared/jenkins/workspace/OSX-64/tools/depends/xbmc-depends/macosx10.10_x86_64-target/lib/python2.6/urllib.py", line 1267, in urlencode
UnicodeEncodeError: 'ascii' codec can't encode character u'\u017e' in position 1: ordinal not in range(128)
-->End of Python script error report<--
```