### PR TITLE
Fix episode sync when setting tv show progress

### DIFF
--- a/program.py
+++ b/program.py
@@ -326,11 +326,11 @@ def setTvshowProgress(show_id, last_season_seen, last_episode_seen):
                 episodes = episodes['result']['episodes']
                 for episode in episodes:
                     log('episode=%s' % episode) 
-                    if (episode['season'] <= last_season_seen and episode['episode'] <= last_episode_seen):               
+                    if (episode['season'] < last_season_seen or (episode['season'] == last_season_seen and episode['episode'] <= last_episode_seen)):
                         command2 = '{"jsonrpc": "2.0", "id": 1, "method": "VideoLibrary.SetEpisodeDetails", "params": {"episodeid" : %s, "playcount": %s}}' % (episode['episodeid'], 1)
                         result2 = json.loads(xbmc.executeJSONRPC(command2))
                         log('watched=%s' % 1)
-                    else:         
+                    else:
                         command2 = '{"jsonrpc": "2.0", "id": 1, "method": "VideoLibrary.SetEpisodeDetails", "params": {"episodeid" : %s, "playcount": %s}}' % (episode['episodeid'], 0)
                         result2 = json.loads(xbmc.executeJSONRPC(command2))
                         log('watched=%s' % 0)


### PR DESCRIPTION
Fixing episode sync TvShowTime > Kodi. Fails to mark as watched certain episodes.

Example case description:
- Having a tv show with 5 seasons each one with 3 episodes.
- When syncing if `last_season_seen` is 3 and `last_episode_seen` is 2, then only S01E01, S01E02, S02E01, S02E02, S03E01, S03E02 will be mark as watched on Kodi's library leaving S01E03, S02E03 unmarked.
- However when you watch S03E03 then S01E03, S02E03 & S03E03 will be mark as watched.
